### PR TITLE
Handle errors gracefully

### DIFF
--- a/app/internal/handlers/proxy.go
+++ b/app/internal/handlers/proxy.go
@@ -116,7 +116,7 @@ func (ph *ProxyHandler) Handle(w http.ResponseWriter, r *http.Request) {
 
 	// Decompress response body if it's gzipped for token parsing
 	var responseBodyForParsing []byte
-	if sessionID != "" && ph.sessionManager != nil {
+	if sessionID != "" && ph.sessionManager != nil && resp.StatusCode >= http.StatusOK && resp.StatusCode < 300 {
 		// Check if response is gzipped
 		contentEncoding := resp.Headers.Get("Content-Encoding")
 		if strings.Contains(strings.ToLower(contentEncoding), "gzip") {


### PR DESCRIPTION
## Summary
- only parse token usage on successful upstream requests
- ensure token parsing skipped on 404 responses

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68446888123c832c9a99b29c87ac0612